### PR TITLE
엔티티 작성 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,10 @@ dependencies {
 
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	
+
+	// valid
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/example/mohago_nocar/course/application/CourseService.java
+++ b/src/main/java/com/example/mohago_nocar/course/application/CourseService.java
@@ -1,0 +1,8 @@
+package com.example.mohago_nocar.course.application;
+
+import com.example.mohago_nocar.course.domain.service.CourseUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CourseService implements CourseUseCase {
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/model/course/Course.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/model/course/Course.java
@@ -1,0 +1,25 @@
+package com.example.mohago_nocar.course.domain.model.course;
+
+import com.example.mohago_nocar.global.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Course extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    public static Course from() {
+        return new Course();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/model/routeStep/RouteStep.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/model/routeStep/RouteStep.java
@@ -1,0 +1,79 @@
+package com.example.mohago_nocar.course.domain.model.routeStep;
+
+import com.example.mohago_nocar.course.domain.model.vo.Location;
+import com.example.mohago_nocar.global.common.domain.BaseEntity;
+import com.example.mohago_nocar.global.util.DurationToIntervalConverter;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class RouteStep extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long courseId;
+
+    @NotNull
+    private Integer distance;
+
+    @NotNull
+    private Integer stepOrder;
+
+    @NotNull
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "longitude", column = @Column(name = "start_longitude")),
+            @AttributeOverride(name = "latitude", column = @Column(name = "start_latitude"))
+    })
+    private Location startLocation;
+
+    @NotNull
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "longitude", column = @Column(name = "end_longitude")),
+            @AttributeOverride(name = "latitude", column = @Column(name = "end_latitude"))
+    })
+    private Location endLocation;
+
+    @NotNull
+    @Convert(converter = DurationToIntervalConverter.class)
+    private Duration timeTaken;
+
+    public static RouteStep from(Long courseId, Integer distance, Integer stepOrder,
+                                 Location startLocation, Location endLocation, Duration timeTaken
+    ) {
+        return RouteStep.builder()
+                .courseId(courseId)
+                .distance(distance)
+                .stepOrder(stepOrder)
+                .startLocation(startLocation)
+                .endLocation(endLocation)
+                .timeTaken(timeTaken)
+                .build();
+    }
+
+    @Builder
+    private RouteStep(Long courseId, Integer distance, Integer stepOrder,
+                     Location startLocation, Location endLocation, Duration timeTaken
+    ) {
+        this.courseId = courseId;
+        this.distance = distance;
+        this.stepOrder = stepOrder;
+        this.startLocation = startLocation;
+        this.endLocation = endLocation;
+        this.timeTaken = timeTaken;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/model/travelSpot/AttractionSpot.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/model/travelSpot/AttractionSpot.java
@@ -1,0 +1,29 @@
+package com.example.mohago_nocar.course.domain.model.travelSpot;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@DiscriminatorValue("ATTRACTION")
+public class AttractionSpot extends TravelSpot {
+
+    public static AttractionSpot from(Long courseId, Integer order) {
+        return AttractionSpot.builder()
+                .courseId(courseId)
+                .order(order)
+                .build();
+    }
+
+    @Builder
+    private AttractionSpot(Long courseId, Integer order) {
+        this.courseId = courseId;
+        this.spotOrder = order;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/model/travelSpot/RestaurantSpot.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/model/travelSpot/RestaurantSpot.java
@@ -1,0 +1,27 @@
+package com.example.mohago_nocar.course.domain.model.travelSpot;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.*;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@DiscriminatorValue("RESTAURANT")
+public class RestaurantSpot extends TravelSpot {
+
+    public static RestaurantSpot from(Long courseId, Integer order) {
+        return RestaurantSpot.builder()
+                .courseId(courseId)
+                .order(order)
+                .build();
+    }
+
+    @Builder
+    private RestaurantSpot(Long courseId, Integer order) {
+        this.courseId = courseId;
+        this.spotOrder = order;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/model/travelSpot/TravelSpot.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/model/travelSpot/TravelSpot.java
@@ -1,0 +1,23 @@
+package com.example.mohago_nocar.course.domain.model.travelSpot;
+
+import com.example.mohago_nocar.global.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "spot_type")
+public abstract class TravelSpot extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    protected Long id;
+
+    @NotNull
+    protected Long courseId;
+
+    @NotNull
+    protected Integer spotOrder;
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/model/vo/Location.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/model/vo/Location.java
@@ -1,0 +1,24 @@
+package com.example.mohago_nocar.course.domain.model.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Location {
+
+    private Double latitude;
+    private Double longitude;
+
+    public static Location from(Double latitude, Double longitude) {
+        return Location.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/repository/CourseRepository.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/repository/CourseRepository.java
@@ -1,0 +1,4 @@
+package com.example.mohago_nocar.course.domain.repository;
+
+public interface CourseRepository {
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/repository/RouteStepRepository.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/repository/RouteStepRepository.java
@@ -1,0 +1,4 @@
+package com.example.mohago_nocar.course.domain.repository;
+
+public interface RouteStepRepository {
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/repository/TravelSpotRepository.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/repository/TravelSpotRepository.java
@@ -1,0 +1,4 @@
+package com.example.mohago_nocar.course.domain.repository;
+
+public interface TravelSpotRepository {
+}

--- a/src/main/java/com/example/mohago_nocar/course/domain/service/CourseUseCase.java
+++ b/src/main/java/com/example/mohago_nocar/course/domain/service/CourseUseCase.java
@@ -1,0 +1,4 @@
+package com.example.mohago_nocar.course.domain.service;
+
+public interface CourseUseCase {
+}

--- a/src/main/java/com/example/mohago_nocar/course/infrastructure/course/CourseJpaRepository.java
+++ b/src/main/java/com/example/mohago_nocar/course/infrastructure/course/CourseJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.mohago_nocar.course.infrastructure.course;
+
+import com.example.mohago_nocar.course.domain.model.course.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseJpaRepository extends JpaRepository<Course, Long> {
+}

--- a/src/main/java/com/example/mohago_nocar/course/infrastructure/course/CourseRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/course/infrastructure/course/CourseRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.example.mohago_nocar.course.infrastructure.course;
+
+import com.example.mohago_nocar.course.domain.repository.CourseRepository;
+import com.example.mohago_nocar.course.infrastructure.course.CourseJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CourseRepositoryImpl implements CourseRepository {
+
+    private CourseJpaRepository courseJpaRepository;
+}

--- a/src/main/java/com/example/mohago_nocar/course/infrastructure/routeStep/RouteStepJpaRepository.java
+++ b/src/main/java/com/example/mohago_nocar/course/infrastructure/routeStep/RouteStepJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.mohago_nocar.course.infrastructure.routeStep;
+
+import com.example.mohago_nocar.course.domain.model.routeStep.RouteStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteStepJpaRepository extends JpaRepository<RouteStep, Long> {
+}

--- a/src/main/java/com/example/mohago_nocar/course/infrastructure/routeStep/RouteStepRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/course/infrastructure/routeStep/RouteStepRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.example.mohago_nocar.course.infrastructure.routeStep;
+
+import com.example.mohago_nocar.course.domain.repository.RouteStepRepository;
+import com.example.mohago_nocar.course.infrastructure.routeStep.RouteStepJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RouteStepRepositoryImpl implements RouteStepRepository {
+
+    private RouteStepJpaRepository routeStepJpaRepository;
+}

--- a/src/main/java/com/example/mohago_nocar/course/infrastructure/travelSpot/TravelSpotJpaRepository.java
+++ b/src/main/java/com/example/mohago_nocar/course/infrastructure/travelSpot/TravelSpotJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.mohago_nocar.course.infrastructure.travelSpot;
+
+import com.example.mohago_nocar.course.domain.model.travelSpot.TravelSpot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelSpotJpaRepository extends JpaRepository<TravelSpot, Long> {
+}

--- a/src/main/java/com/example/mohago_nocar/course/infrastructure/travelSpot/TravelSpotRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/course/infrastructure/travelSpot/TravelSpotRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.example.mohago_nocar.course.infrastructure.travelSpot;
+
+import com.example.mohago_nocar.course.domain.repository.TravelSpotRepository;
+import com.example.mohago_nocar.course.infrastructure.travelSpot.TravelSpotJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TravelSpotRepositoryImpl implements TravelSpotRepository {
+
+    private TravelSpotJpaRepository travelSpotJpaRepository;
+}

--- a/src/main/java/com/example/mohago_nocar/course/presentation/CourseController.java
+++ b/src/main/java/com/example/mohago_nocar/course/presentation/CourseController.java
@@ -1,0 +1,9 @@
+package com.example.mohago_nocar.course.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CourseController {
+}

--- a/src/main/java/com/example/mohago_nocar/festival/application/FestivalService.java
+++ b/src/main/java/com/example/mohago_nocar/festival/application/FestivalService.java
@@ -1,0 +1,10 @@
+package com.example.mohago_nocar.festival.application;
+
+import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FestivalService implements FestivalUseCase {
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/model/Festival.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/model/Festival.java
@@ -1,0 +1,60 @@
+package com.example.mohago_nocar.festival.domain.model;
+
+import com.example.mohago_nocar.festival.domain.model.vo.ActivePeriod;
+import com.example.mohago_nocar.festival.domain.model.vo.Address;
+import com.example.mohago_nocar.festival.domain.model.vo.Location;
+import com.example.mohago_nocar.global.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Festival extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    @Embedded
+    private ActivePeriod activePeriod;
+
+    @NotNull
+    private String description;
+
+    @NotNull
+    @Embedded
+    private Address address;
+
+    @NotNull
+    @Embedded
+    private Location location;
+
+    public static Festival from(String name, ActivePeriod activePeriod, String description, Address address, Location location) {
+        return Festival.builder()
+                .name(name)
+                .activePeriod(activePeriod)
+                .description(description)
+                .address(address)
+                .location(location)
+                .build();
+    }
+
+    @Builder
+    private Festival(String name, ActivePeriod activePeriod, String description, Address address, Location location) {
+        this.name = name;
+        this.activePeriod = activePeriod;
+        this.description = description;
+        this.address = address;
+        this.location = location;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/model/FestivalImage.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/model/FestivalImage.java
@@ -1,0 +1,46 @@
+package com.example.mohago_nocar.festival.domain.model;
+
+import com.example.mohago_nocar.global.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+public class FestivalImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long festivalId;
+
+    @NotNull
+    private String imageUrl;
+
+    public static FestivalImage from(Long festivalId, String imageUrl) {
+        return FestivalImage.builder()
+                .festivalId(festivalId)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+    @Builder
+    private FestivalImage(Long festivalId, String imageUrl) {
+        this.festivalId = festivalId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/model/vo/ActivePeriod.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/model/vo/ActivePeriod.java
@@ -1,0 +1,26 @@
+package com.example.mohago_nocar.festival.domain.model.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Embeddable
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ActivePeriod {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    public static ActivePeriod from(LocalDate startDate, LocalDate endDate) {
+        return ActivePeriod.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/model/vo/Address.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/model/vo/Address.java
@@ -1,0 +1,36 @@
+package com.example.mohago_nocar.festival.domain.model.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Address {
+
+    private String roadNameAddress;
+
+    private String jibunAddress;
+
+    private String postalCode;
+
+    // 시/도
+    private String city;
+
+    // 구/군/구역
+    private String district;
+
+    public static Address from(String roadNameAddress, String jibunAddress, String postalCode, String city, String district) {
+        return Address.builder()
+                .roadNameAddress(roadNameAddress)
+                .jibunAddress(jibunAddress)
+                .postalCode(postalCode)
+                .city(city)
+                .district(district)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/model/vo/Location.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/model/vo/Location.java
@@ -1,0 +1,24 @@
+package com.example.mohago_nocar.festival.domain.model.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Location {
+
+    private Double latitude;
+    private Double longitude;
+
+    public static Location from(Double latitude, Double longitude) {
+        return Location.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/repository/FestivalRepository.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/repository/FestivalRepository.java
@@ -1,0 +1,4 @@
+package com.example.mohago_nocar.festival.domain.repository;
+
+public interface FestivalRepository {
+}

--- a/src/main/java/com/example/mohago_nocar/festival/domain/service/FestivalUseCase.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/service/FestivalUseCase.java
@@ -1,0 +1,4 @@
+package com.example.mohago_nocar.festival.domain.service;
+
+public interface FestivalUseCase {
+}

--- a/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalJpaRepository.java
+++ b/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.mohago_nocar.festival.infrastructure;
+
+import com.example.mohago_nocar.festival.domain.model.Festival;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FestivalJpaRepository extends JpaRepository<Festival, Long> {
+}

--- a/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.example.mohago_nocar.festival.infrastructure;
+
+import com.example.mohago_nocar.festival.domain.repository.FestivalRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FestivalRepositoryImpl implements FestivalRepository {
+
+    private FestivalJpaRepository festivalJpaRepository;
+}

--- a/src/main/java/com/example/mohago_nocar/festival/presentation/FestivalController.java
+++ b/src/main/java/com/example/mohago_nocar/festival/presentation/FestivalController.java
@@ -1,0 +1,9 @@
+package com.example.mohago_nocar.festival.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FestivalController {
+}

--- a/src/main/java/com/example/mohago_nocar/global/common/domain/BaseEntity.java
+++ b/src/main/java/com/example/mohago_nocar/global/common/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.mohago_nocar.global.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/mohago_nocar/global/util/DurationToIntervalConverter.java
+++ b/src/main/java/com/example/mohago_nocar/global/util/DurationToIntervalConverter.java
@@ -1,0 +1,21 @@
+package com.example.mohago_nocar.global.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.Duration;
+
+@Converter(autoApply = true)
+public class DurationToIntervalConverter implements AttributeConverter<Duration, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Duration duration) {
+        return duration == null ? null : duration.toString();
+    }
+
+    @Override
+    public Duration convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : Duration.parse(dbData);
+    }
+}
+


### PR DESCRIPTION
## 📄 PR 요약

설계를 바탕으로 도출된 엔티티를 작성하였습니다.

## 📋 관련 이슈

- #2 

## 🛠️ 변경 사항 설명

- postgreSQL `order` 예약어 이슈로 인해 필드명을 변경하였습니다 .
    - `TravelSpot`의 order -> **spotOrder**
    -  `RouteStep`의 order -> **stepOrder**

- 요구사항 변경으로 인한 side effect를 최소화하기 위해, 기존의 `TravelSpot`을 enum 타입인 `Attraction`과 `Restaurant`으로 구분하는 설계를 `TravelSpot`을 상속받는 `RestaurantSpot`과 `AttractionSpot`을 사용하는 설계로 변경하였습니다.
    - 상속관계 매핑 전략으로는 SINGLE_TABLE 을 사용하였습니다.
   

## 📄 추가 정보

>      TravelSpot의 order -> spotOrder
>      RouteStep의 order -> stepOrder
로 필드명을 변경한 사항에 관하여, 더 좋은 필드명이 있다면 언제든지 말씀주세요! 
