### PR TITLE
setting: 스웨거 세팅 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/example/mohago_nocar/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/mohago_nocar/global/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.example.mohago_nocar.global.config;
+
+import io.swagger.v3.oas.models.info.Contact;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI springBootAPI() {
+        Info info = new Info()
+                .title("\uD83D\uDE97 ❌뭐하고 no car")
+                .description("뭐하고 no car Server API 문서")
+                .contact(new Contact().name("전민주").url("https://github.com/mingmingmon").email("mingmingmon@naver.com"));
+
+        Server server = new Server().url("/");
+
+        return new OpenAPI()
+                .servers(List.of(server))
+                .info(info);
+    }
+}


### PR DESCRIPTION
## 📄 PR 요약

API 문서를 확인할 수 있는 스웨거 세팅을 완료했습니다.

## 📋 관련 이슈

#11 

## 🛠️ 변경 사항 설명

스웨거에 접속해서 내가 작성한 API를 테스트해볼 수 있게 되었습니다.
`http://localhost:6060/swagger-ui/index.html#/`라는 주소로 접속할 수 있습니다.
이때 포트번호는 본인이 환경변수로 설정한 포트로 설정해주세요!

## 📷 스크린샷

동작 사진 입니다.
<img width="951" alt="image" src="https://github.com/user-attachments/assets/edf345ff-547d-48b0-974f-7107ec5ce768">

## 📄 추가 정보

@mungsil 해당 작업을 위해 스프링부트를 실행해보니 `("classpath:env.properties")`에서 파일을 찾을 수 없다고 나왔습니다. 
해당 파일 공유 가능할까요?? 아마 git ignore로 처리돼서 그런 것 같습니다!
