### PR TITLE
축제 주변 장소 저장 기능 구현 완료

### DIFF
--- a/src/main/java/com/example/mohago_nocar/festival/application/FestivalService.java
+++ b/src/main/java/com/example/mohago_nocar/festival/application/FestivalService.java
@@ -44,4 +44,10 @@ public class FestivalService implements FestivalUseCase {
                 .orElseThrow(FestivalNotFoundException::new);
         return FestivalLocationResponseDto.of(festival.getLocation());
     }
+
+    @Override
+    public List<Festival> getAllFestivals() {
+
+        return festivalRepository.getAllFestivals();
+    }
 }

--- a/src/main/java/com/example/mohago_nocar/festival/application/FestivalService.java
+++ b/src/main/java/com/example/mohago_nocar/festival/application/FestivalService.java
@@ -7,9 +7,12 @@ import com.example.mohago_nocar.festival.domain.repository.FestivalRepository;
 import com.example.mohago_nocar.festival.domain.service.FestivalImageUseCase;
 import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
 import com.example.mohago_nocar.festival.infrastructure.FestivalImageJpaRepository;
+import com.example.mohago_nocar.festival.presentation.exception.FestivalNotFoundException;
+import com.example.mohago_nocar.festival.presentation.response.FestivalLocationResponseDto;
 import com.example.mohago_nocar.festival.presentation.response.FestivalResponseDto;
 import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,5 +36,12 @@ public class FestivalService implements FestivalUseCase {
                     }
                 );
         return new PagedResponseDto<>(pagedFestivalResponseDto);
+    }
+
+    @Override
+    public FestivalLocationResponseDto getFestivalLocation(Long festivalId) {
+        Festival festival = festivalRepository.getFestivalById(festivalId)
+                .orElseThrow(FestivalNotFoundException::new);
+        return FestivalLocationResponseDto.of(festival.getLocation());
     }
 }

--- a/src/main/java/com/example/mohago_nocar/festival/domain/repository/FestivalRepository.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/repository/FestivalRepository.java
@@ -1,10 +1,13 @@
 package com.example.mohago_nocar.festival.domain.repository;
 
 import com.example.mohago_nocar.festival.domain.model.Festival;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface FestivalRepository {
 
     Page<Festival> getFestivals(Pageable pageable);
+
+    Optional<Festival> getFestivalById(Long id);
 }

--- a/src/main/java/com/example/mohago_nocar/festival/domain/repository/FestivalRepository.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/repository/FestivalRepository.java
@@ -1,6 +1,8 @@
 package com.example.mohago_nocar.festival.domain.repository;
 
 import com.example.mohago_nocar.festival.domain.model.Festival;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,4 +12,6 @@ public interface FestivalRepository {
     Page<Festival> getFestivals(Pageable pageable);
 
     Optional<Festival> getFestivalById(Long id);
+
+    List<Festival> getAllFestivals();
 }

--- a/src/main/java/com/example/mohago_nocar/festival/domain/service/FestivalUseCase.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/service/FestivalUseCase.java
@@ -1,10 +1,14 @@
 package com.example.mohago_nocar.festival.domain.service;
 
+import com.example.mohago_nocar.festival.presentation.response.FestivalLocationResponseDto;
 import com.example.mohago_nocar.festival.presentation.response.FestivalResponseDto;
 import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 
 public interface FestivalUseCase {
 
     PagedResponseDto<FestivalResponseDto> fetchFestivals(Pageable pageable);
+
+   FestivalLocationResponseDto getFestivalLocation(Long festivalId);
 }

--- a/src/main/java/com/example/mohago_nocar/festival/domain/service/FestivalUseCase.java
+++ b/src/main/java/com/example/mohago_nocar/festival/domain/service/FestivalUseCase.java
@@ -1,8 +1,11 @@
 package com.example.mohago_nocar.festival.domain.service;
 
+import com.example.mohago_nocar.festival.domain.model.Festival;
 import com.example.mohago_nocar.festival.presentation.response.FestivalLocationResponseDto;
 import com.example.mohago_nocar.festival.presentation.response.FestivalResponseDto;
 import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 
@@ -11,4 +14,6 @@ public interface FestivalUseCase {
     PagedResponseDto<FestivalResponseDto> fetchFestivals(Pageable pageable);
 
    FestivalLocationResponseDto getFestivalLocation(Long festivalId);
+
+    List<Festival> getAllFestivals();
 }

--- a/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.example.mohago_nocar.festival.infrastructure;
 
 import com.example.mohago_nocar.festival.domain.model.Festival;
 import com.example.mohago_nocar.festival.domain.repository.FestivalRepository;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,5 +24,10 @@ public class FestivalRepositoryImpl implements FestivalRepository {
     @Override
     public Optional<Festival> getFestivalById(Long id) {
         return festivalJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Festival> getAllFestivals() {
+        return festivalJpaRepository.findAll();
     }
 }

--- a/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/festival/infrastructure/FestivalRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.example.mohago_nocar.festival.infrastructure;
 
 import com.example.mohago_nocar.festival.domain.model.Festival;
 import com.example.mohago_nocar.festival.domain.repository.FestivalRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,5 +17,10 @@ public class FestivalRepositoryImpl implements FestivalRepository {
     @Override
     public Page<Festival> getFestivals(Pageable pageable) {
         return festivalJpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Optional<Festival> getFestivalById(Long id) {
+        return festivalJpaRepository.findById(id);
     }
 }

--- a/src/main/java/com/example/mohago_nocar/festival/presentation/exception/FestivalExceptionCode.java
+++ b/src/main/java/com/example/mohago_nocar/festival/presentation/exception/FestivalExceptionCode.java
@@ -1,0 +1,23 @@
+package com.example.mohago_nocar.festival.presentation.exception;
+
+import com.example.mohago_nocar.global.common.exception.GlobalStatus;
+import com.example.mohago_nocar.global.common.exception.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum FestivalExceptionCode implements Status {
+    FESTIVAL_NOT_FOUND(NOT_FOUND, "축제를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/presentation/exception/FestivalNotFoundException.java
+++ b/src/main/java/com/example/mohago_nocar/festival/presentation/exception/FestivalNotFoundException.java
@@ -1,0 +1,13 @@
+package com.example.mohago_nocar.festival.presentation.exception;
+
+import com.example.mohago_nocar.global.common.exception.CustomException;
+import com.example.mohago_nocar.global.common.exception.GlobalStatus;
+
+import static com.example.mohago_nocar.festival.presentation.exception.FestivalExceptionCode.FESTIVAL_NOT_FOUND;
+
+public class FestivalNotFoundException extends CustomException {
+
+    public FestivalNotFoundException() {
+        super(FESTIVAL_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/festival/presentation/response/FestivalLocationResponseDto.java
+++ b/src/main/java/com/example/mohago_nocar/festival/presentation/response/FestivalLocationResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.mohago_nocar.festival.presentation.response;
+
+import com.example.mohago_nocar.global.common.domain.vo.Location;
+import lombok.Builder;
+
+@Builder
+public record FestivalLocationResponseDto(
+        Location location
+) {
+    public static FestivalLocationResponseDto of(Location location) {
+        return new FestivalLocationResponseDtoBuilder()
+                .location(location)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/global/common/domain/vo/Location.java
+++ b/src/main/java/com/example/mohago_nocar/global/common/domain/vo/Location.java
@@ -14,13 +14,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Location {
 
-    private Double latitude;
-    private Double longitude;
+    private Double longitude; // x
+    private Double latitude; // y
 
-    public static Location from(Double latitude, Double longitude) {
+    public static Location from(Double longitude, Double latitude) {
         return Location.builder()
-                .latitude(latitude)
                 .longitude(longitude)
+                .latitude(latitude)
                 .build();
     }
 }

--- a/src/main/java/com/example/mohago_nocar/global/common/exception/CustomException.java
+++ b/src/main/java/com/example/mohago_nocar/global/common/exception/CustomException.java
@@ -4,19 +4,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private GlobalStatus globalStatus;
+    private Status status;
 
-    public CustomException(String message, GlobalStatus errorStatus) {
-        super(message);
-        this.globalStatus = errorStatus;
-    }
-
-    public CustomException(GlobalStatus errorStatus) {
-        super(errorStatus.getMessage());
-        this.globalStatus = errorStatus;
-    }
-
-    public Body getBody() {
-        return this.globalStatus.getBody();
+    public CustomException(Status status) {
+        super(status.getMessage());
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/mohago_nocar/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/mohago_nocar/global/common/exception/GlobalExceptionHandler.java
@@ -87,10 +87,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleGeneralException(
             CustomException e
     ) {
-        log.warn(">>> handle: GeneralException | " +e.getGlobalStatus() + e);
+        log.warn(">>> handle: GeneralException | " +e.getStatus() + e);
 
-        ApiResponse<Object> response = ApiResponse.onFailure(e.getGlobalStatus().getCode(), e.getMessage(), null);
-        return ResponseEntity.status(e.getGlobalStatus().getHttpStatus()).body(response);
+        ApiResponse<Object> response = ApiResponse.onFailure(e.getStatus().getCode(), e.getMessage(), null);
+        return ResponseEntity.status(e.getStatus().getHttpStatus()).body(response);
     }
 
     /**

--- a/src/main/java/com/example/mohago_nocar/place/application/PlaceService.java
+++ b/src/main/java/com/example/mohago_nocar/place/application/PlaceService.java
@@ -1,13 +1,20 @@
 package com.example.mohago_nocar.place.application;
 
+import com.example.mohago_nocar.festival.domain.model.Festival;
 import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
 import com.example.mohago_nocar.festival.presentation.response.FestivalLocationResponseDto;
+import com.example.mohago_nocar.place.application.converter.PlaceConverter;
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlaceImage;
+import com.example.mohago_nocar.place.domain.repository.FestivalNearPlaceImageRepository;
+import com.example.mohago_nocar.place.domain.repository.FestivalNearPlaceRepository;
 import com.example.mohago_nocar.place.domain.service.PlaceUseCase;
 import com.example.mohago_nocar.place.infrastructure.externalApi.GoogleApiClient;
-import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.PlaceResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,10 +22,47 @@ public class PlaceService implements PlaceUseCase {
 
     private final GoogleApiClient googleApiClient;
     private final FestivalUseCase festivalUseCase;
+    private final FestivalNearPlaceRepository festivalNearPlaceRepository;
+    private final FestivalNearPlaceImageRepository festivalNearPlaceImageRepository;
+
+    private static final int RADIUS = 1500;
 
     @Override
-    public GoogleNearByPlaceResponse fetchPlaces(Long festivalId, Pageable pageable) {
-        FestivalLocationResponseDto responseDto = festivalUseCase.getFestivalLocation(festivalId);
-        return googleApiClient.request(responseDto.location().getLatitude(), responseDto.location().getLongitude(), 1500);
+    @Transactional
+    public void updateAllFestivalNearbyPlaces() {
+        List<Festival> festivals = festivalUseCase.getAllFestivals();
+        festivals.forEach(festival -> updateFestivalNearbyPlaces(festival.getId()));
+    }
+
+    private void updateFestivalNearbyPlaces(Long festivalId) {
+        FestivalLocationResponseDto festivalLocation = festivalUseCase.getFestivalLocation(festivalId);
+        List<PlaceResponseDto> nearbyPlaces = getNearbyPlacesFrom(festivalLocation);
+
+        saveNearbyPlaces(festivalId, nearbyPlaces);
+    }
+
+    private List<PlaceResponseDto> getNearbyPlacesFrom(FestivalLocationResponseDto festivalLocation) {
+        return googleApiClient.findNearbyPlaces(
+                festivalLocation.location().getLatitude(),
+                festivalLocation.location().getLongitude(),
+                RADIUS
+        );
+    }
+
+    private void saveNearbyPlaces(Long festivalId, List<PlaceResponseDto> nearbyPlaces) {
+        nearbyPlaces.forEach(placeDto -> {
+            FestivalNearPlace savedPlace = saveFestivalNearPlace(festivalId, placeDto);
+            saveFestivalNearPlaceImages(savedPlace.getId(), placeDto.getPhotos());
+        });
+    }
+
+    private FestivalNearPlace saveFestivalNearPlace(Long festivalId, PlaceResponseDto placeDto) {
+        FestivalNearPlace place = PlaceConverter.convertToFestivalNearPlace(festivalId, placeDto);
+        return festivalNearPlaceRepository.save(place);
+    }
+
+    private void saveFestivalNearPlaceImages(Long placeId, List<String> photos) {
+        List<FestivalNearPlaceImage> placeImages = PlaceConverter.convertToFestivalNearPlaceImage(placeId, photos);
+        placeImages.forEach(festivalNearPlaceImageRepository::save);
     }
 }

--- a/src/main/java/com/example/mohago_nocar/place/application/PlaceService.java
+++ b/src/main/java/com/example/mohago_nocar/place/application/PlaceService.java
@@ -3,7 +3,7 @@ package com.example.mohago_nocar.place.application;
 import com.example.mohago_nocar.festival.domain.model.Festival;
 import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
 import com.example.mohago_nocar.festival.presentation.response.FestivalLocationResponseDto;
-import com.example.mohago_nocar.place.application.converter.PlaceConverter;
+import com.example.mohago_nocar.place.application.mapper.FestivalNearPlaceMapper;
 import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
 import com.example.mohago_nocar.place.domain.model.FestivalNearPlaceImage;
 import com.example.mohago_nocar.place.domain.repository.FestivalNearPlaceImageRepository;
@@ -36,20 +36,19 @@ public class PlaceService implements PlaceUseCase {
 
     private void updateFestivalNearbyPlaces(Long festivalId) {
         FestivalLocationResponseDto festivalLocation = festivalUseCase.getFestivalLocation(festivalId);
-        List<PlaceResponseDto> nearbyPlaces = getNearbyPlacesFrom(festivalLocation);
-
-        saveNearbyPlaces(festivalId, nearbyPlaces);
+        List<PlaceResponseDto> nearbyPlaces = searchNearbyPlacesWithImages(festivalLocation);
+        saveNearbyPlacesWithImages(festivalId, nearbyPlaces);
     }
 
-    private List<PlaceResponseDto> getNearbyPlacesFrom(FestivalLocationResponseDto festivalLocation) {
-        return googleApiClient.findNearbyPlaces(
+    private List<PlaceResponseDto> searchNearbyPlacesWithImages(FestivalLocationResponseDto festivalLocation) {
+        return googleApiClient.searchNearbyPlacesWithImageUris(
                 festivalLocation.location().getLatitude(),
                 festivalLocation.location().getLongitude(),
                 RADIUS
         );
     }
 
-    private void saveNearbyPlaces(Long festivalId, List<PlaceResponseDto> nearbyPlaces) {
+    private void saveNearbyPlacesWithImages(Long festivalId, List<PlaceResponseDto> nearbyPlaces) {
         nearbyPlaces.forEach(placeDto -> {
             FestivalNearPlace savedPlace = saveFestivalNearPlace(festivalId, placeDto);
             saveFestivalNearPlaceImages(savedPlace.getId(), placeDto.getPhotos());
@@ -57,12 +56,12 @@ public class PlaceService implements PlaceUseCase {
     }
 
     private FestivalNearPlace saveFestivalNearPlace(Long festivalId, PlaceResponseDto placeDto) {
-        FestivalNearPlace place = PlaceConverter.convertToFestivalNearPlace(festivalId, placeDto);
+        FestivalNearPlace place = FestivalNearPlaceMapper.convertToFestivalNearPlace(festivalId, placeDto);
         return festivalNearPlaceRepository.save(place);
     }
 
     private void saveFestivalNearPlaceImages(Long placeId, List<String> photos) {
-        List<FestivalNearPlaceImage> placeImages = PlaceConverter.convertToFestivalNearPlaceImage(placeId, photos);
+        List<FestivalNearPlaceImage> placeImages = FestivalNearPlaceMapper.convertToFestivalNearPlaceImage(placeId, photos);
         placeImages.forEach(festivalNearPlaceImageRepository::save);
     }
 }

--- a/src/main/java/com/example/mohago_nocar/place/application/PlaceService.java
+++ b/src/main/java/com/example/mohago_nocar/place/application/PlaceService.java
@@ -1,0 +1,24 @@
+package com.example.mohago_nocar.place.application;
+
+import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
+import com.example.mohago_nocar.festival.presentation.response.FestivalLocationResponseDto;
+import com.example.mohago_nocar.place.domain.service.PlaceUseCase;
+import com.example.mohago_nocar.place.infrastructure.externalApi.GoogleApiClient;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService implements PlaceUseCase {
+
+    private final GoogleApiClient googleApiClient;
+    private final FestivalUseCase festivalUseCase;
+
+    @Override
+    public GoogleNearByPlaceResponse fetchPlaces(Long festivalId, Pageable pageable) {
+        FestivalLocationResponseDto responseDto = festivalUseCase.getFestivalLocation(festivalId);
+        return googleApiClient.request(responseDto.location().getLatitude(), responseDto.location().getLongitude(), 1500);
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/application/converter/PlaceConverter.java
+++ b/src/main/java/com/example/mohago_nocar/place/application/converter/PlaceConverter.java
@@ -1,0 +1,42 @@
+package com.example.mohago_nocar.place.application.converter;
+
+import com.example.mohago_nocar.global.common.domain.vo.Location;
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlaceImage;
+import com.example.mohago_nocar.place.domain.model.OperatingSchedule;
+import com.example.mohago_nocar.place.domain.model.PlaceType;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.PlaceResponseDto;
+import java.util.List;
+
+
+public class PlaceConverter {
+
+    public static FestivalNearPlace convertToFestivalNearPlace(Long festivalId, PlaceResponseDto dto) {
+
+        String placeName = dto.getPlaceName();
+        OperatingSchedule schedule = getSchedule(dto);
+        Location location = getLocation(dto);
+        String address = dto.getAddress();
+        String description = dto.getDescription();
+        PlaceType placeType = getPlaceType(dto);
+        String googlePlaceId = dto.getId();
+
+        return FestivalNearPlace.from(festivalId, placeName, schedule, location, address, description, placeType, googlePlaceId);
+    }
+
+    private static OperatingSchedule getSchedule(PlaceResponseDto dto) {
+        return OperatingSchedule.from(dto.getSchedule());
+    }
+
+    private static Location getLocation(PlaceResponseDto dto) {
+        return Location.from(dto.getLatitude(), dto.getLongitude());
+    }
+
+    private static PlaceType getPlaceType(PlaceResponseDto dto) {
+        return PlaceType.from(dto.getPlaceType());
+    }
+
+    public static List<FestivalNearPlaceImage> convertToFestivalNearPlaceImage(Long festivalId, List<String> photos) {
+        return photos.stream().map(photo -> FestivalNearPlaceImage.from(festivalId, photo)).toList();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/application/mapper/FestivalNearPlaceMapper.java
+++ b/src/main/java/com/example/mohago_nocar/place/application/mapper/FestivalNearPlaceMapper.java
@@ -1,4 +1,4 @@
-package com.example.mohago_nocar.place.application.converter;
+package com.example.mohago_nocar.place.application.mapper;
 
 import com.example.mohago_nocar.global.common.domain.vo.Location;
 import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
@@ -9,7 +9,7 @@ import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.Pl
 import java.util.List;
 
 
-public class PlaceConverter {
+public class FestivalNearPlaceMapper {
 
     public static FestivalNearPlace convertToFestivalNearPlace(Long festivalId, PlaceResponseDto dto) {
 

--- a/src/main/java/com/example/mohago_nocar/place/application/mapper/FestivalNearPlaceMapper.java
+++ b/src/main/java/com/example/mohago_nocar/place/application/mapper/FestivalNearPlaceMapper.java
@@ -29,7 +29,7 @@ public class FestivalNearPlaceMapper {
     }
 
     private static Location getLocation(PlaceResponseDto dto) {
-        return Location.from(dto.getLatitude(), dto.getLongitude());
+        return Location.from(dto.getLongitude(), dto.getLatitude());
     }
 
     private static PlaceType getPlaceType(PlaceResponseDto dto) {

--- a/src/main/java/com/example/mohago_nocar/place/domain/model/FestivalNearPlace.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/model/FestivalNearPlace.java
@@ -1,0 +1,93 @@
+package com.example.mohago_nocar.place.domain.model;
+
+import com.example.mohago_nocar.global.common.domain.vo.Location;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FestivalNearPlace {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private Long festivalId;
+
+    @NotNull
+    @Embedded
+    private OperatingSchedule operatingSchedule;
+
+    @NotNull
+    @Embedded
+    private Location location;
+
+    @NotNull
+    private String address;
+
+    @NotNull
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @NotNull
+    @Enumerated(value = STRING)
+    private PlaceType placeType;
+
+    @NotNull
+    private String googlePlaceId;
+
+    public static FestivalNearPlace from(
+            Long festivalId,
+            String name,
+            OperatingSchedule operatingSchedule,
+            Location location,
+            String address,
+            String description,
+            PlaceType placeType,
+            String googlePlaceId
+    ) {
+        return FestivalNearPlace.builder()
+                .festivalId(festivalId)
+                .name(name)
+                .operatingSchedule(operatingSchedule)
+                .location(location)
+                .address(address)
+                .description(description)
+                .placeType(placeType)
+                .googlePlaceId(googlePlaceId)
+                .build();
+    }
+
+    @Builder
+    private FestivalNearPlace(
+            Long festivalId,
+            String name,
+            OperatingSchedule operatingSchedule,
+            Location location,
+            String address,
+            String description,
+            PlaceType placeType,
+            String googlePlaceId
+    ) {
+        this.festivalId = festivalId;
+        this.name = name;
+        this.operatingSchedule = operatingSchedule;
+        this.location = location;
+        this.address = address;
+        this.description = description;
+        this.placeType = placeType;
+        this.googlePlaceId = googlePlaceId;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/domain/model/FestivalNearPlaceImage.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/model/FestivalNearPlaceImage.java
@@ -1,0 +1,42 @@
+package com.example.mohago_nocar.place.domain.model;
+
+import com.example.mohago_nocar.festival.domain.model.FestivalImage;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FestivalNearPlaceImage {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long festivalNearPlaceId;
+
+    @NotNull
+    private String imageUrl;
+
+    public static FestivalNearPlaceImage from(Long festivalId, String imageUrl) {
+        return FestivalNearPlaceImage.builder()
+                .festivalNearPlaceId(festivalId)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+    @Builder
+    private FestivalNearPlaceImage(Long festivalNearPlaceId, String imageUrl) {
+        this.festivalNearPlaceId = festivalNearPlaceId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/domain/model/OperatingSchedule.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/model/OperatingSchedule.java
@@ -1,0 +1,64 @@
+package com.example.mohago_nocar.place.domain.model;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.JoinColumn;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class OperatingSchedule {
+
+    private static final int MAX_DAYS_IN_WEEK = 7;
+
+    @ElementCollection
+    @CollectionTable(name = "operating_hours", joinColumns = @JoinColumn(name = "festival_near_place_id"))
+    private List<OperatingHour> schedule = new ArrayList<>();
+
+    public List<OperatingHour> getOperatingHours() {
+        return schedule;
+    }
+
+    public static OperatingSchedule from(List<String> operatingHours) {
+        if (operatingHours.size() > MAX_DAYS_IN_WEEK) {
+            throw new IllegalArgumentException("Operating hours cannot exceed " + MAX_DAYS_IN_WEEK + " days.");
+        }
+
+        OperatingSchedule operatingSchedule = new OperatingSchedule();
+        operatingHours.forEach(operatingSchedule::addOperatingHours);
+
+        return operatingSchedule;
+    }
+
+    private void addOperatingHours(String operatingHour) {
+        schedule.add(OperatingHour.from(operatingHour));
+    }
+
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor(access = PROTECTED)
+    public static class OperatingHour {
+
+        private String operatingHour;
+
+        public static OperatingHour from(String operatingHour) {
+            return OperatingHour.builder()
+                    .operatingHour(operatingHour)
+                    .build();
+        }
+
+        @Builder
+        private OperatingHour(String operatingHour) {
+            this.operatingHour = operatingHour;
+        }
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/domain/model/PlaceType.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/model/PlaceType.java
@@ -1,0 +1,40 @@
+package com.example.mohago_nocar.place.domain.model;
+
+public enum PlaceType {
+    RESTAURANT, ATTRACTION;
+
+    public static PlaceType from(String placeType) {
+        return switch (placeType.toLowerCase()) {
+            case
+                    "restaurant",
+                    "barbecue_restaurant",
+                    "bakery",
+                    "breakfast_restaurant",
+                    "brunch_restaurant",
+                    "cafe",
+                    "chinese_restaurant",
+                    "coffee_shop",
+                    "fast_food_restaurant",
+                    "french_restaurant",
+                    "hamburger_restaurant",
+                    "ice_cream_shop",
+                    "indian_restaurant",
+                    "indonesian_restaurant",
+                    "italian_restaurant",
+                    "japanese_restaurant",
+                    "korean_restaurant",
+                    "mediterranean_restaurant",
+                    "mexican_restaurant",
+                    "middle_eastern_restaurant",
+                    "pizza_restaurant",
+                    "ramen_restaurant",
+                    "sandwich_shop",
+                    "seafood_restaurant",
+                    "steak_house",
+                    "sushi_restaurant"
+                    -> RESTAURANT;
+
+            default -> ATTRACTION;
+        };
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/domain/model/PlaceType.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/model/PlaceType.java
@@ -4,37 +4,16 @@ public enum PlaceType {
     RESTAURANT, ATTRACTION;
 
     public static PlaceType from(String placeType) {
-        return switch (placeType.toLowerCase()) {
-            case
-                    "restaurant",
-                    "barbecue_restaurant",
-                    "bakery",
-                    "breakfast_restaurant",
-                    "brunch_restaurant",
-                    "cafe",
-                    "chinese_restaurant",
-                    "coffee_shop",
-                    "fast_food_restaurant",
-                    "french_restaurant",
-                    "hamburger_restaurant",
-                    "ice_cream_shop",
-                    "indian_restaurant",
-                    "indonesian_restaurant",
-                    "italian_restaurant",
-                    "japanese_restaurant",
-                    "korean_restaurant",
-                    "mediterranean_restaurant",
-                    "mexican_restaurant",
-                    "middle_eastern_restaurant",
-                    "pizza_restaurant",
-                    "ramen_restaurant",
-                    "sandwich_shop",
-                    "seafood_restaurant",
-                    "steak_house",
-                    "sushi_restaurant"
-                    -> RESTAURANT;
+        if (placeType.contains("음식점")
+                || placeType.contains("식당")
+                || placeType.contains("카페")
+                || placeType.contains("커피숍/커피 전문점")
+                || placeType.contains("제과점")
+                || placeType.contains("아이스크림 가게")
+        ) {
+            return RESTAURANT;
+        }
 
-            default -> ATTRACTION;
-        };
+        return ATTRACTION;
     }
 }

--- a/src/main/java/com/example/mohago_nocar/place/domain/repository/FestivalNearPlaceImageRepository.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/repository/FestivalNearPlaceImageRepository.java
@@ -1,0 +1,8 @@
+package com.example.mohago_nocar.place.domain.repository;
+
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlaceImage;
+
+public interface FestivalNearPlaceImageRepository {
+
+    FestivalNearPlaceImage save(FestivalNearPlaceImage image);
+}

--- a/src/main/java/com/example/mohago_nocar/place/domain/repository/FestivalNearPlaceRepository.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/repository/FestivalNearPlaceRepository.java
@@ -1,0 +1,8 @@
+package com.example.mohago_nocar.place.domain.repository;
+
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
+
+public interface FestivalNearPlaceRepository {
+
+    FestivalNearPlace save(FestivalNearPlace place);
+}

--- a/src/main/java/com/example/mohago_nocar/place/domain/service/PlaceUseCase.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/service/PlaceUseCase.java
@@ -1,10 +1,6 @@
 package com.example.mohago_nocar.place.domain.service;
 
-import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
-import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
-import org.springframework.data.domain.Pageable;
-
 public interface PlaceUseCase {
 
-    GoogleNearByPlaceResponse fetchPlaces(Long festivalId, Pageable pageable);
+    void updateAllFestivalNearbyPlaces();
 }

--- a/src/main/java/com/example/mohago_nocar/place/domain/service/PlaceUseCase.java
+++ b/src/main/java/com/example/mohago_nocar/place/domain/service/PlaceUseCase.java
@@ -1,0 +1,10 @@
+package com.example.mohago_nocar.place.domain.service;
+
+import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface PlaceUseCase {
+
+    GoogleNearByPlaceResponse fetchPlaces(Long festivalId, Pageable pageable);
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceImageJpaRepository.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceImageJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.mohago_nocar.place.infrastructure;
+
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlaceImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FestivalNearPlaceImageJpaRepository extends JpaRepository<FestivalNearPlaceImage, Long> {
+
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceImageRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceImageRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.example.mohago_nocar.place.infrastructure;
+
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlaceImage;
+import com.example.mohago_nocar.place.domain.repository.FestivalNearPlaceImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FestivalNearPlaceImageRepositoryImpl implements FestivalNearPlaceImageRepository {
+
+    private final FestivalNearPlaceImageJpaRepository festivalNearPlaceImageJpaRepository;
+
+    @Override
+    public FestivalNearPlaceImage save(FestivalNearPlaceImage image) {
+        return festivalNearPlaceImageJpaRepository.save(image);
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceJpaRepository.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.mohago_nocar.place.infrastructure;
+
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FestivalNearPlaceJpaRepository extends JpaRepository<FestivalNearPlace, Long> {
+
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceRepositoryImpl.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/FestivalNearPlaceRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.example.mohago_nocar.place.infrastructure;
+
+import com.example.mohago_nocar.place.domain.model.FestivalNearPlace;
+import com.example.mohago_nocar.place.domain.repository.FestivalNearPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FestivalNearPlaceRepositoryImpl implements FestivalNearPlaceRepository {
+
+    private final FestivalNearPlaceJpaRepository festivalNearPlaceJpaRepository;
+
+    @Override
+    public FestivalNearPlace save(FestivalNearPlace place) {
+        return festivalNearPlaceJpaRepository.save(place);
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
@@ -3,7 +3,6 @@ package com.example.mohago_nocar.place.infrastructure.externalApi;
 import com.example.mohago_nocar.place.infrastructure.externalApi.dto.request.GoogleNearPlaceRequest;
 import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.GoogleNearbyPlaceResponse;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.GooglePlaceImageResponse;
@@ -108,7 +107,7 @@ public class GoogleApiClient {
 
     public List<PlaceResponseDto> findNearbyPlaces(double festivalX, double festivalY, int radius) {
         URI requestURI = buildNearPlaceRequestURI();
-        GoogleNearbyPlaceResponse googleNearPlaceResponse = fetchNearPlace(requestURI, festivalX, festivalY, radius);
+        GoogleNearbyPlaceResponse googleNearPlaceResponse = fetchNearPlaceResponse(requestURI, festivalX, festivalY, radius);
 
         List<PlaceResponseDto> placeResponseDtos = PlaceMapper.mapGoogleNearPlaceResponseToPlaceResponseDtos(googleNearPlaceResponse);
 
@@ -122,7 +121,7 @@ public class GoogleApiClient {
                 .toUri();
     }
 
-    private GoogleNearbyPlaceResponse fetchNearPlace(URI requestURI, double festivalX, double festivalY, int radius) {
+    private GoogleNearbyPlaceResponse fetchNearPlaceResponse(URI requestURI, double festivalX, double festivalY, int radius) {
         GoogleNearPlaceRequest requestBody = GoogleNearPlaceRequest.of(
                 REQUEST_PLACE_TYPES, MAX_RESULT_COUNT, festivalX, festivalY, radius, RANK_PREFERENCE, LANGUAGE_CODE);
 
@@ -163,15 +162,16 @@ public class GoogleApiClient {
     }
 
     private List<String> findGooglePlaceImage(List<String> photoNames) {
-        List<String> placeImageUris = new ArrayList<>();
-        for (String name : photoNames) {
-            URI uri = buildPlaceImageRequestURI(name);
-            GooglePlaceImageResponse imageUri = fetchPlaceImage(uri);
+        return photoNames.stream()
+                .map(this::fetchPlaceImageUri)
+                .collect(Collectors.toList());
+    }
 
-            placeImageUris.add(imageUri.photoUri());
-        }
+    private String fetchPlaceImageUri(String photoName) {
+        URI uri = buildPlaceImageRequestURI(photoName);
+        GooglePlaceImageResponse imageResponse = fetchPlaceImageResponse(uri);
 
-        return placeImageUris;
+        return imageResponse.photoUri();
     }
 
     private URI buildPlaceImageRequestURI(String name) {
@@ -185,7 +185,7 @@ public class GoogleApiClient {
                 .toUri();
     }
 
-    private GooglePlaceImageResponse fetchPlaceImage(URI uri) {
+    private GooglePlaceImageResponse fetchPlaceImageResponse(URI uri) {
         try {
             return restClient.get()
                     .uri(uri)

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
@@ -1,61 +1,200 @@
 package com.example.mohago_nocar.place.infrastructure.externalApi;
 
-import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.request.GoogleNearPlaceRequest;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.GoogleNearbyPlaceResponse;
 import java.net.URI;
-import java.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.GooglePlaceImageResponse;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.PlaceResponseDto;
+import com.example.mohago_nocar.place.infrastructure.externalApi.mapper.PlaceMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@Slf4j
 public class GoogleApiClient {
 
     private final RestClient restClient;
     private final String apiKey;
     private final String baseUrl;
 
+    private static final int MAX_RESULT_COUNT = 20;
+
+    private static final String RANK_PREFERENCE = "POPULARITY";
+
+    private static final String LANGUAGE_CODE = "ko";
+
+    private static final String FIELD_MASK = String.join(",",
+            "places.displayName",
+            "places.nationalPhoneNumber",
+            "places.id",
+            "places.formattedAddress",
+            "places.rating",
+            "places.userRatingCount",
+            "places.location",
+            "places.websiteUri",
+            "places.regularOpeningHours.weekdayDescriptions",
+            "places.primaryTypeDisplayName",
+            "places.editorialSummary",
+            "places.generativeSummary",
+            "places.photos.name");
+
+    private static final List<String> REQUEST_PLACE_TYPES = List.of(
+            "art_gallery",
+            "museum",
+            "performing_arts_theater",
+            "amusement_center",
+            "amusement_park",
+            "aquarium",
+            "banquet_hall",
+            "bowling_alley",
+            "casino",
+            "hiking_area",
+            "historical_landmark",
+            "marina",
+            "movie_rental",
+            "movie_theater",
+            "national_park",
+            "night_club",
+            "park",
+            "zoo",
+            "american_restaurant",
+            "bakery",
+            "bar",
+            "barbecue_restaurant",
+            "breakfast_restaurant",
+            "brunch_restaurant",
+            "cafe",
+            "chinese_restaurant",
+            "coffee_shop",
+            "fast_food_restaurant",
+            "french_restaurant",
+            "hamburger_restaurant",
+            "ice_cream_shop",
+            "indian_restaurant",
+            "indonesian_restaurant",
+            "italian_restaurant",
+            "japanese_restaurant",
+            "korean_restaurant",
+            "mediterranean_restaurant",
+            "mexican_restaurant",
+            "middle_eastern_restaurant",
+            "pizza_restaurant",
+            "ramen_restaurant",
+            "restaurant",
+            "sandwich_shop",
+            "seafood_restaurant",
+            "steak_house",
+            "sushi_restaurant",
+            "spa",
+            "gift_shop",
+            "shopping_mall",
+            "playground"
+    );
+
     public GoogleApiClient(
-            RestClient restClient,
+            RestClient.Builder restClient,
             @Value("${google.api-key}") String apiKey,
             @Value("${google.url}") String baseUrl) {
-        this.restClient = restClient;
-        this.apiKey =  apiKey;
+        this.restClient = restClient.build();
+        this.apiKey = apiKey;
         this.baseUrl = baseUrl;
     }
 
-    public GoogleNearByPlaceResponse request(double festivalX, double festivalY, int radius) {
-        URI requestURI = buildRequestURI(festivalX, festivalY, radius);
-        System.out.println(requestURI);
-        return fetchGoogleNearByPlaceResponse(requestURI);
+    public List<PlaceResponseDto> findNearbyPlaces(double festivalX, double festivalY, int radius) {
+        URI requestURI = buildNearPlaceRequestURI();
+        GoogleNearbyPlaceResponse googleNearPlaceResponse = fetchNearPlace(requestURI, festivalX, festivalY, radius);
+
+        List<PlaceResponseDto> placeResponseDtos = PlaceMapper.mapGoogleNearPlaceResponseToPlaceResponseDtos(googleNearPlaceResponse);
+
+        return convertPhotoNamesToUris(placeResponseDtos);
     }
 
-    private URI buildRequestURI(double festivalX, double festivalY, int radius) {
+    private URI buildNearPlaceRequestURI() {
         return UriComponentsBuilder.fromUriString(baseUrl)
-                .queryParam("location", festivalX + "%2C" + festivalY)
-                .queryParam("radius", radius)
-                .queryParam("language", "ko")
-                .queryParam("type", "restaurant")
-                .queryParam("key", apiKey)
+                .path("places:searchNearby")
                 .build(true)
                 .toUri();
     }
 
-    private GoogleNearByPlaceResponse fetchGoogleNearByPlaceResponse(URI requestURI) {
-        GoogleNearByPlaceResponse response = restClient.get()
-                .uri(requestURI)
-                .retrieve()
-                .body(GoogleNearByPlaceResponse.class);
+    private GoogleNearbyPlaceResponse fetchNearPlace(URI requestURI, double festivalX, double festivalY, int radius) {
+        GoogleNearPlaceRequest requestBody = GoogleNearPlaceRequest.of(
+                REQUEST_PLACE_TYPES, MAX_RESULT_COUNT, festivalX, festivalY, radius, RANK_PREFERENCE, LANGUAGE_CODE);
 
-        System.out.println(restClient.get()
-                .uri(requestURI)
-                .retrieve()
-                .body(GoogleNearByPlaceResponse.class));
+        try {
+            return restClient.post()
+                    .uri(requestURI)
+                    .header("X-Goog-Api-Key", apiKey)
+                    .header("Content-Type", "application/json")
+                    .header("X-Goog-FieldMask", FIELD_MASK)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(GoogleNearbyPlaceResponse.class);
 
-        return Objects.requireNonNullElseGet(response, () -> {
-            //커스텀 예외 처리
-            throw new RuntimeException("축제 주변 정보 조회 실패");
-        });
+        } catch (Exception e) {
+            // TODO: 커스텀 에러 변경
+            throw new RuntimeException(e.getMessage());
+        }
+
     }
 
+    /**
+     * Google API 요청을 통해 주어진 PlaceResponseDto List의 photos 필드 값을 photoName에서 photoUri로 변환합니다.
+     *
+     * @param placeResponseDtos 변환할 PlaceResponseDto 목록 (변환 전의 photos 필드 값은 photoName)
+     * @return 변환된 PlaceResponseDto 목록 (photos 필드 값은 photoUri)
+     */
+    private List<PlaceResponseDto> convertPhotoNamesToUris(List<PlaceResponseDto> placeResponseDtos) {
+        return placeResponseDtos.stream()
+                .map(this::convertPhotoNamesToUrisForDto)
+                .collect(Collectors.toList());
+    }
+
+    private PlaceResponseDto convertPhotoNamesToUrisForDto(PlaceResponseDto placeResponseDto) {
+        List<String> photoNames = placeResponseDto.getPhotos();
+        List<String> photoUris = findGooglePlaceImage(photoNames);
+
+        return placeResponseDto.withUpdatedPhotos(photoUris);
+    }
+
+    private List<String> findGooglePlaceImage(List<String> photoNames) {
+        List<String> placeImageUris = new ArrayList<>();
+        for (String name : photoNames) {
+            URI uri = buildPlaceImageRequestURI(name);
+            GooglePlaceImageResponse imageUri = fetchPlaceImage(uri);
+
+            placeImageUris.add(imageUri.photoUri());
+        }
+
+        return placeImageUris;
+    }
+
+    private URI buildPlaceImageRequestURI(String name) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
+                .path(name)
+                .path("/media")
+                .queryParam("key", apiKey)
+                .queryParam("maxHeightPx", 4800)
+                .queryParam("skipHttpRedirect", true)
+                .build(true)
+                .toUri();
+    }
+
+    private GooglePlaceImageResponse fetchPlaceImage(URI uri) {
+        try {
+            return restClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .body(GooglePlaceImageResponse.class);
+
+        } catch (Exception e) {
+            // TODO: 커스텀 에러 변경
+            throw new RuntimeException(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.GooglePlaceImageResponse;
 import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.PlaceResponseDto;
-import com.example.mohago_nocar.place.infrastructure.externalApi.mapper.PlaceMapper;
+import com.example.mohago_nocar.place.infrastructure.externalApi.mapper.GooglePlaceMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -105,11 +105,10 @@ public class GoogleApiClient {
         this.baseUrl = baseUrl;
     }
 
-    public List<PlaceResponseDto> findNearbyPlaces(double festivalX, double festivalY, int radius) {
+    public List<PlaceResponseDto> searchNearbyPlacesWithImageUris(double festivalX, double festivalY, int radius) {
         URI requestURI = buildNearPlaceRequestURI();
         GoogleNearbyPlaceResponse googleNearPlaceResponse = fetchNearPlaceResponse(requestURI, festivalX, festivalY, radius);
-
-        List<PlaceResponseDto> placeResponseDtos = PlaceMapper.mapGoogleNearPlaceResponseToPlaceResponseDtos(googleNearPlaceResponse);
+        List<PlaceResponseDto> placeResponseDtos = GooglePlaceMapper.mapGoogleNearPlaceResponseToPlaceResponseDtos(googleNearPlaceResponse);
 
         return convertPhotoNamesToUris(placeResponseDtos);
     }
@@ -156,18 +155,18 @@ public class GoogleApiClient {
 
     private PlaceResponseDto convertPhotoNamesToUrisForDto(PlaceResponseDto placeResponseDto) {
         List<String> photoNames = placeResponseDto.getPhotos();
-        List<String> photoUris = findGooglePlaceImage(photoNames);
+        List<String> photoUris = searchPlaceImagesFrom(photoNames);
 
         return placeResponseDto.withUpdatedPhotos(photoUris);
     }
 
-    private List<String> findGooglePlaceImage(List<String> photoNames) {
+    private List<String> searchPlaceImagesFrom(List<String> photoNames) {
         return photoNames.stream()
-                .map(this::fetchPlaceImageUri)
+                .map(this::searchPlaceImageUri)
                 .collect(Collectors.toList());
     }
 
-    private String fetchPlaceImageUri(String photoName) {
+    private String searchPlaceImageUri(String photoName) {
         URI uri = buildPlaceImageRequestURI(photoName);
         GooglePlaceImageResponse imageResponse = fetchPlaceImageResponse(uri);
 

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
@@ -1,0 +1,61 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi;
+
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import java.net.URI;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class GoogleApiClient {
+
+    private final RestClient restClient;
+    private final String apiKey;
+    private final String baseUrl;
+
+    public GoogleApiClient(
+            RestClient restClient,
+            @Value("${google.api-key}") String apiKey,
+            @Value("${google.url}") String baseUrl) {
+        this.restClient = restClient;
+        this.apiKey =  apiKey;
+        this.baseUrl = baseUrl;
+    }
+
+    public GoogleNearByPlaceResponse request(double festivalX, double festivalY, int radius) {
+        URI requestURI = buildRequestURI(festivalX, festivalY, radius);
+        System.out.println(requestURI);
+        return fetchGoogleNearByPlaceResponse(requestURI);
+    }
+
+    private URI buildRequestURI(double festivalX, double festivalY, int radius) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
+                .queryParam("location", festivalX + "%2C" + festivalY)
+                .queryParam("radius", radius)
+                .queryParam("language", "ko")
+                .queryParam("type", "restaurant")
+                .queryParam("key", apiKey)
+                .build(true)
+                .toUri();
+    }
+
+    private GoogleNearByPlaceResponse fetchGoogleNearByPlaceResponse(URI requestURI) {
+        GoogleNearByPlaceResponse response = restClient.get()
+                .uri(requestURI)
+                .retrieve()
+                .body(GoogleNearByPlaceResponse.class);
+
+        System.out.println(restClient.get()
+                .uri(requestURI)
+                .retrieve()
+                .body(GoogleNearByPlaceResponse.class));
+
+        return Objects.requireNonNullElseGet(response, () -> {
+            //커스텀 예외 처리
+            throw new RuntimeException("축제 주변 정보 조회 실패");
+        });
+    }
+
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/GoogleNearByPlaceResponse.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/GoogleNearByPlaceResponse.java
@@ -1,9 +1,0 @@
-package com.example.mohago_nocar.place.infrastructure.externalApi.dto;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import java.util.Optional;
-
-public record GoogleNearByPlaceResponse(
-        Optional<JsonNode> results
-) {
-}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/GoogleNearByPlaceResponse.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/GoogleNearByPlaceResponse.java
@@ -1,0 +1,9 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
+
+public record GoogleNearByPlaceResponse(
+        Optional<JsonNode> results
+) {
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/request/GoogleNearPlaceRequest.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/request/GoogleNearPlaceRequest.java
@@ -1,0 +1,32 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.dto.request;
+
+import lombok.Builder;
+import java.util.List;
+
+
+@Builder
+public record GoogleNearPlaceRequest(
+        List<String> includedTypes,
+        int maxResultCount,
+        LocationRestriction locationRestriction,
+        String rankPreference,
+        String languageCode
+) {
+    public static GoogleNearPlaceRequest of(
+            List<String> includedTypes,
+            int maxResultCount,
+            double latitude,
+            double longitude,
+            double radius,
+            String rankPreference,
+            String languageCode
+    ) {
+        return GoogleNearPlaceRequest.builder()
+                .includedTypes(includedTypes)
+                .maxResultCount(maxResultCount)
+                .locationRestriction(LocationRestriction.of(latitude, longitude, radius))
+                .rankPreference(rankPreference)
+                .languageCode(languageCode)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/request/LocationRestriction.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/request/LocationRestriction.java
@@ -1,0 +1,40 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record LocationRestriction(
+        Circle circle
+) {
+    public static LocationRestriction of(double latitude, double longitude, double radius) {
+        return LocationRestriction.builder()
+                .circle(Circle.of(latitude, longitude, radius))
+                .build();
+    }
+
+    @Builder
+    public record Circle(
+            Center center,
+            double radius
+    ) {
+        public static Circle of(double latitude, double longitude, double radius) {
+            return Circle.builder()
+                    .center(Center.of(latitude, longitude))
+                    .radius(radius)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record Center(
+            double latitude,
+            double longitude
+    ) {
+        public static Center of(double latitude, double longitude) {
+            return Center.builder()
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/response/GoogleNearbyPlaceResponse.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/response/GoogleNearbyPlaceResponse.java
@@ -1,0 +1,8 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.dto.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record GoogleNearbyPlaceResponse(
+        JsonNode places
+) {
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/response/GooglePlaceImageResponse.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/response/GooglePlaceImageResponse.java
@@ -1,0 +1,6 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.dto.response;
+
+public record GooglePlaceImageResponse(
+        String photoUri
+) {
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/dto/response/PlaceResponseDto.java
@@ -1,0 +1,95 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PlaceResponseDto {
+
+    private final String id;
+    private final String address;
+    private final Double latitude;
+    private final Double longitude;
+    private final Double rating;
+    private final Integer ratingCount;
+    private final String placeName;
+    private final String placeType;
+    private final List<String> photos;
+    private final String editorialSummary;
+    private final String generativeSummary;
+    private final List<String> schedule;
+
+    private static final String NO_DESCRIPTION_MESSAGE = "장소 소개가 제공되지 않습니다";
+
+    private static final String N0_SCHEDULE_MESSAGE = "영업 시간이 제공되지 않는 장소입니다";
+
+    public static PlaceResponseDto of(
+            String id,
+            String address,
+            Double latitude,
+            Double longitude,
+            Double rating,
+            Integer userRatingCount,
+            String placeName,
+            String placeType,
+            List<String> photos,
+            String editorialSummary,
+            String generativeSummary,
+            List<String> schedule
+    ) {
+        return PlaceResponseDto.builder()
+                .id(id)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .rating(rating)
+                .ratingCount(userRatingCount)
+                .placeName(placeName)
+                .placeType(placeType)
+                .photos(photos)
+                .editorialSummary(editorialSummary)
+                .generativeSummary(generativeSummary)
+                .schedule(schedule)
+                .build();
+    }
+
+    public PlaceResponseDto withUpdatedPhotos(List<String> photos) {
+        return PlaceResponseDto.builder()
+                .id(this.id)
+                .address(this.address)
+                .latitude(this.latitude)
+                .longitude(this.longitude)
+                .rating(this.rating)
+                .ratingCount(this.ratingCount)
+                .placeName(this.placeName)
+                .placeType(this.placeType)
+                .photos(photos)
+                .editorialSummary(this.editorialSummary)
+                .generativeSummary(this.generativeSummary)
+                .schedule(this.schedule)
+                .build();
+    }
+
+    public String getDescription() {
+        if (editorialSummary != null && !editorialSummary.isEmpty()) {
+            return editorialSummary;
+        }
+
+        if (generativeSummary != null && !generativeSummary.isEmpty()) {
+            return generativeSummary;
+        }
+
+        return NO_DESCRIPTION_MESSAGE;
+    }
+
+    public List<String> getSchedule() {
+        if (this.schedule.isEmpty()) {
+            return List.of(N0_SCHEDULE_MESSAGE);
+        }
+
+        return this.schedule;
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/mapper/GooglePlaceMapper.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/mapper/GooglePlaceMapper.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class PlaceMapper {
+public class GooglePlaceMapper {
 
     public static List<PlaceResponseDto> mapGoogleNearPlaceResponseToPlaceResponseDtos(GoogleNearbyPlaceResponse googleNearbyPlaceResponse) {
         JsonNode placesNode = googleNearbyPlaceResponse.places();
@@ -18,7 +18,7 @@ public class PlaceMapper {
     private static List<PlaceResponseDto> mapPlacesNodeToResponseDtos(JsonNode placesNode) {
 
         return streamJsonNodeOrEmpty(placesNode)
-                .map(PlaceMapper::mapPlaceNodeToDto)
+                .map(GooglePlaceMapper::mapPlaceNodeToDto)
                 .toList();
     }
 

--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/mapper/PlaceMapper.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/mapper/PlaceMapper.java
@@ -1,0 +1,100 @@
+package com.example.mohago_nocar.place.infrastructure.externalApi.mapper;
+
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.GoogleNearbyPlaceResponse;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.PlaceResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class PlaceMapper {
+
+    public static List<PlaceResponseDto> mapGoogleNearPlaceResponseToPlaceResponseDtos(GoogleNearbyPlaceResponse googleNearbyPlaceResponse) {
+        JsonNode placesNode = googleNearbyPlaceResponse.places();
+
+        return mapPlacesNodeToResponseDtos(placesNode);
+    }
+
+    private static List<PlaceResponseDto> mapPlacesNodeToResponseDtos(JsonNode placesNode) {
+
+        return streamJsonNodeOrEmpty(placesNode)
+                .map(PlaceMapper::mapPlaceNodeToDto)
+                .toList();
+    }
+
+    private static PlaceResponseDto mapPlaceNodeToDto(JsonNode place) {
+        String id = place.get("id").asText();
+        String address = place.get("formattedAddress").asText();
+
+        // location
+        JsonNode locationNode = place.get("location");
+        Double latitude = locationNode.get("latitude").asDouble();
+        Double longitude = locationNode.get("longitude").asDouble();
+
+        // place name
+        String placeName = place.get("displayName").get("text").asText();
+
+        // place type (nullable)
+        String placeType = place.has("primaryTypeDisplayName") && !place.get("primaryTypeDisplayName").isNull()
+                ? place.get("primaryTypeDisplayName").get("text").asText() : "unknown";
+
+        // rating (nullable)
+        Double rating = place.has("rating") && !place.get("rating").isNull()
+                ? place.get("rating").asDouble() : (double) 0;
+
+        // userRatingCount (nullable)
+        Integer userRatingCount = place.has("userRatingCount") && !place.get("userRatingCount").isNull()
+                ? place.get("userRatingCount").asInt() : 0;
+
+        // photos (nullable)
+        JsonNode photoNodes = place.has("photos") && !place.get("photos").isNull()
+                ? place.get("photos") : null;
+        List<String> photoNames = extractPhotoName(photoNodes);
+
+        // summary (nullable)
+        String editorialSummary = place.has("editorialSummary") && !place.get("editorialSummary").isNull()
+                ? place.get("editorialSummary").get("text").asText() : null;
+
+        String generativeSummary = place.has("generativeSummary") && !place.get("generativeSummary").isNull()
+                ? place.get("generativeSummary").get("description").get("text").asText() : null;
+
+        // schedule (nullable)
+        JsonNode scheduleNode = place.has("regularOpeningHours") && !place.get("regularOpeningHours").isNull()
+                ? place.get("regularOpeningHours").get("weekdayDescriptions") : null;
+        List<String> schedule = extractSchedule(scheduleNode);
+
+        return PlaceResponseDto.of(
+                id,
+                address,
+                latitude,
+                longitude,
+                rating,
+                userRatingCount,
+                placeName,
+                placeType,
+                photoNames,
+                editorialSummary,
+                generativeSummary,
+                schedule
+        );
+    }
+
+    private static List<String> extractPhotoName(JsonNode photoNodes) {
+        return streamJsonNodeOrEmpty(photoNodes)
+                .map(photo -> photo.get("name").asText())
+                .toList();
+    }
+
+    private static List<String> extractSchedule(JsonNode scheduleNode) {
+        return streamJsonNodeOrEmpty(scheduleNode)
+                .map(JsonNode::asText)
+                .toList();
+    }
+
+    private static Stream<JsonNode> streamJsonNodeOrEmpty(JsonNode node) {
+        if (node == null || !node.isArray()) {
+            return Stream.empty();
+        }
+        return StreamSupport.stream(node.spliterator(), false);
+    }
+}

--- a/src/main/java/com/example/mohago_nocar/place/presentation/PlaceController.java
+++ b/src/main/java/com/example/mohago_nocar/place/presentation/PlaceController.java
@@ -1,39 +1,29 @@
 package com.example.mohago_nocar.place.presentation;
 
-import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
-import com.example.mohago_nocar.festival.presentation.response.FestivalResponseDto;
-import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
 import com.example.mohago_nocar.global.common.response.ApiResponse;
 import com.example.mohago_nocar.place.domain.service.PlaceUseCase;
-import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.response.PlaceResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/places")
+@RequestMapping("/api/v1/nearby-places")
 @RequiredArgsConstructor
 @Tag(name = "Place", description = "축제 주변 장소")
 public class PlaceController {
 
     private final PlaceUseCase placeUseCase;
 
-    @Operation(summary = "축제 주변 장소 조회", description = "축제 주변 장소 정보를 반환합니다. 페이지네이션이 적용되어있습니다.")
-    @GetMapping("/{festivalId}")
-    public ApiResponse<GoogleNearByPlaceResponse> fetchPlaces(
-            @PathVariable(name = "festivalId") Long festivalId,
-            @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size
-    ) {
-        Pageable pageable = PageRequest.of(page, size);
-        GoogleNearByPlaceResponse pagedResponse = placeUseCase.fetchPlaces(festivalId, pageable);
-        return ApiResponse.ok(pagedResponse);
+    @Operation(summary = "축제 주변 장소 업데이트", description = "축제 주변 장소 정보를 업데이트합니다. ")
+    @PatchMapping("/update")
+    public ApiResponse<List<PlaceResponseDto>> updateFestivalNearPlaces() {
+        placeUseCase.updateAllFestivalNearbyPlaces();
+        return ApiResponse.ok(null);
     }
 }

--- a/src/main/java/com/example/mohago_nocar/place/presentation/PlaceController.java
+++ b/src/main/java/com/example/mohago_nocar/place/presentation/PlaceController.java
@@ -1,0 +1,39 @@
+package com.example.mohago_nocar.place.presentation;
+
+import com.example.mohago_nocar.festival.domain.service.FestivalUseCase;
+import com.example.mohago_nocar.festival.presentation.response.FestivalResponseDto;
+import com.example.mohago_nocar.global.common.dto.PagedResponseDto;
+import com.example.mohago_nocar.global.common.response.ApiResponse;
+import com.example.mohago_nocar.place.domain.service.PlaceUseCase;
+import com.example.mohago_nocar.place.infrastructure.externalApi.dto.GoogleNearByPlaceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/places")
+@RequiredArgsConstructor
+@Tag(name = "Place", description = "축제 주변 장소")
+public class PlaceController {
+
+    private final PlaceUseCase placeUseCase;
+
+    @Operation(summary = "축제 주변 장소 조회", description = "축제 주변 장소 정보를 반환합니다. 페이지네이션이 적용되어있습니다.")
+    @GetMapping("/{festivalId}")
+    public ApiResponse<GoogleNearByPlaceResponse> fetchPlaces(
+            @PathVariable(name = "festivalId") Long festivalId,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        GoogleNearByPlaceResponse pagedResponse = placeUseCase.fetchPlaces(festivalId, pageable);
+        return ApiResponse.ok(pagedResponse);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,5 +34,5 @@ odsay:
   api-key: ${ODSAY_API_KEY}
 
 google:
-  url : https://maps.googleapis.com/maps/api/place/nearbysearch/json?
+  url : https://places.googleapis.com/v1/
   api-key : ${GOOGLE_API_KEY}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,3 +32,7 @@ springdoc:
 odsay:
   url: https://api.odsay.com/v1/api/searchPubTransPathT
   api-key: ${ODSAY_API_KEY}
+
+google:
+  url : https://maps.googleapis.com/maps/api/place/nearbysearch/json?
+  api-key : ${GOOGLE_API_KEY}


### PR DESCRIPTION
## 📄 PR 요약

`Google Maps API`를 이용하여 축제 주변 장소 정보를 가져와 데이터베이스에 저장하는 API를 구현하였습니다. 이때 장소의 이미지도 함께 저장합니다.


## 📋 관련 이슈

- close: #17 

## 🛠️ 변경 사항 설명

- @mingmingmon 님이 구현하셨던 기존 API (2c2707088b2ba183b58a2f417d844e6dade28b78)는 주변 장소를 **조회**하는 기능만 제공했습니다. 이로 인해 `Google Maps API`를 여러 번 호출하게 되어 성능 문제가 발생했었는데, 이를 개선하기 위해 논의를 나눈대로 다음과 같은 작업을 수행했습니다.
    - API 호출 횟수를 줄이기 위해 `Google Maps API` 결과를 데이터베이스에 저장하도록 변경했습니다.
    - 새로운 버전의 `Place API`를 사용하였습니다.

- 새로운 `Place API` 덕분에, 한 번의 요청으로 여러 장소 타입을 조회할 수 있게 되었습니다. 음식점, 카페, 베이커리 등은 `RESTAURANT`로 분류하고, 나머지는 `ATTRACTION`으로 분류했습니다.

- 기존 설계가 변경되어 축제 주변 장소 정보가 데이터베이스에 저장됩니다. 이 과정에서 추가된 엔티티들을 확인해 주세요.

- 장소 설명이 없는 경우 "장소 소개가 제공되지 않습니다."라는 기본 메시지를 설정했습니다.

- 영업 시간이 없는 경우 "영업 시간이 제공되지 않는 장소입니다."라는 기본 메시지를 설정했습니다.

## 📄 추가 정보

현재 구현된 `/api/v1/nearby-places/update` API는 모든 축제에 대해 주변 장소를 조회하여 데이터베이스에 단순 저장합니다. 추후 `spring batch` 등을 사용해 주기적으로 정보를 업데이트하는 자동화 로직을 추가할 예정입니다. 자동 업데이트 로직이 완성되면 수동으로 호출하는 이 API는 삭제할 계획입니다. 현재는 제가 `/api/v1/nearby-places/update` API를 이미 호출하여 RDS에 정보가 저장된 상태이므로, 중복 저장에 유의해 주시기 바랍니다.