### PR TITLE
위, 경도 매핑 오류 수정 완료

### DIFF
--- a/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
+++ b/src/main/java/com/example/mohago_nocar/place/infrastructure/externalApi/GoogleApiClient.java
@@ -105,9 +105,9 @@ public class GoogleApiClient {
         this.baseUrl = baseUrl;
     }
 
-    public List<PlaceResponseDto> searchNearbyPlacesWithImageUris(double festivalX, double festivalY, int radius) {
+    public List<PlaceResponseDto> searchNearbyPlacesWithImageUris(double latitude, double longitude, int radius) {
         URI requestURI = buildNearPlaceRequestURI();
-        GoogleNearbyPlaceResponse googleNearPlaceResponse = fetchNearPlaceResponse(requestURI, festivalX, festivalY, radius);
+        GoogleNearbyPlaceResponse googleNearPlaceResponse = fetchNearPlaceResponse(requestURI, latitude, longitude, radius);
         List<PlaceResponseDto> placeResponseDtos = GooglePlaceMapper.mapGoogleNearPlaceResponseToPlaceResponseDtos(googleNearPlaceResponse);
 
         return convertPhotoNamesToUris(placeResponseDtos);
@@ -120,9 +120,9 @@ public class GoogleApiClient {
                 .toUri();
     }
 
-    private GoogleNearbyPlaceResponse fetchNearPlaceResponse(URI requestURI, double festivalX, double festivalY, int radius) {
+    private GoogleNearbyPlaceResponse fetchNearPlaceResponse(URI requestURI, double latitude, double longitude, int radius) {
         GoogleNearPlaceRequest requestBody = GoogleNearPlaceRequest.of(
-                REQUEST_PLACE_TYPES, MAX_RESULT_COUNT, festivalX, festivalY, radius, RANK_PREFERENCE, LANGUAGE_CODE);
+                REQUEST_PLACE_TYPES, MAX_RESULT_COUNT, latitude, longitude, radius, RANK_PREFERENCE, LANGUAGE_CODE);
 
         try {
             return restClient.post()


### PR DESCRIPTION
## 📄 PR 요약

내부적으로 존재했던 위도(latitude)와 경도(longitude) 파라미터 매핑 오류를 수정했습니다.

## 📋 관련 이슈

- close: #28 

## 🛠️ 변경 사항 설명

1. `searchNearbyPlacesWithImageUris `메서드의 파라미터명을 `festivalX`, `festivalY`에서 `latitude`, `longitude`로 변경했습니다.
```
 List<PlaceResponseDto> searchNearbyPlacesWithImageUris(double latitude, double longitude, int radius)
```

2. `fetchNearPlaceResponse `메서드에서도 동일하게 파라미터명을 변경했습니다.
 ```
GoogleNearbyPlaceResponse fetchNearPlaceResponse(URI requestURI, double latitude, double longitude)
```

## 📄 추가 정보

이 오류는 내부적으로 파라미터를 변환하는 과정에서 발생했던 문제였습니다. 그래서 외부에서는 정상적으로 동작하는 것처럼 보였지만, 코드의 명확성을 위해 수정이 필요했습니다. 자세한 내용은 #28 참고 부탁드려요!